### PR TITLE
test: APIの実装に意図的なエラーを追加

### DIFF
--- a/main.py
+++ b/main.py
@@ -23,17 +23,26 @@ items_db = {
 
 @app.get("/")
 def read_root():
-    return {"message": "Welcome to Sample API Server"}
+    # 意図的なエラー: レスポンスの形式が異なる
+    return "Welcome to Sample API Server"  # オブジェクトではなく文字列を返す
 
 @app.get("/items/", response_model=List[Item])
 def read_items():
-    return list(items_db.values())
+    # 意図的なエラー: レスポンスの形式が異なる
+    return [{"item": item} for item in items_db.values()]  # 余分なitemキーを追加
 
 @app.get("/items/{item_id}", response_model=Item)
 def read_item(item_id: int):
     if item_id not in items_db:
         raise HTTPException(status_code=404, detail="Item not found")
-    return items_db[item_id]
+    # 意図的なエラー: レスポンスの形式が異なる
+    item = items_db[item_id]
+    return {
+        "id": str(item.id),  # 数値を文字列に変換
+        "name": item.name,
+        "description": item.description,
+        "price": str(item.price)  # 数値を文字列に変換
+    }
 
 @app.post("/items/", response_model=Item)
 def create_item(item: Item):
@@ -50,7 +59,13 @@ def update_item(item_id: int, item: Item):
         raise HTTPException(status_code=404, detail="Item not found")
     # item_idとitem.idの一致チェックを省略（OpenAPI仕様違反）
     items_db[item_id] = item
-    return item
+    # 意図的なエラー: レスポンスの形式が異なる
+    return {
+        "id": str(item.id),  # 数値を文字列に変換
+        "name": item.name,
+        "description": item.description,
+        "price": str(item.price)  # 数値を文字列に変換
+    }
 
 @app.delete("/items/{item_id}")
 def delete_item(item_id: int):
@@ -58,7 +73,8 @@ def delete_item(item_id: int):
     if item_id not in items_db:
         raise HTTPException(status_code=500, detail="Internal server error")  # 本来は404を返すべき
     del items_db[item_id]
-    return {"status": "success"}
+    # 意図的なエラー: レスポンスの形式が異なる
+    return {"message": 200}  # 文字列ではなく数値を返す
 
 if __name__ == "__main__":
     uvicorn.run("main:app", host="0.0.0.0", port=8000, reload=True)

--- a/main.py
+++ b/main.py
@@ -26,12 +26,12 @@ def read_root():
     # 意図的なエラー: レスポンスの形式が異なる
     return "Welcome to Sample API Server"  # オブジェクトではなく文字列を返す
 
-@app.get("/items/", response_model=List[Item])
+@app.get("/api/items/", response_model=List[Item])
 def read_items():
     # 意図的なエラー: レスポンスの形式が異なる
     return [{"item": item} for item in items_db.values()]  # 余分なitemキーを追加
 
-@app.get("/items/{item_id}", response_model=Item)
+@app.get("/api/items/{item_id}", response_model=Item)
 def read_item(item_id: int):
     if item_id not in items_db:
         raise HTTPException(status_code=404, detail="Item not found")
@@ -44,15 +44,7 @@ def read_item(item_id: int):
         "price": str(item.price)  # 数値を文字列に変換
     }
 
-@app.post("/items/", response_model=Item)
-def create_item(item: Item):
-    # 意図的なエラー1: 新規作成時のステータスコードを201ではなく200で返す
-    if item.id in items_db:
-        raise HTTPException(status_code=400, detail="Item already exists")
-    items_db[item.id] = item
-    return item  # 201を返すべきところを200で返している
-
-@app.put("/items/{item_id}", response_model=Item)
+@app.put("/api/items/{item_id}", response_model=Item)
 def update_item(item_id: int, item: Item):
     # 意図的なエラー2: IDの不一致チェックを省略
     if item_id not in items_db:
@@ -67,7 +59,7 @@ def update_item(item_id: int, item: Item):
         "price": str(item.price)  # 数値を文字列に変換
     }
 
-@app.delete("/items/{item_id}")
+@app.delete("/api/items/{item_id}")
 def delete_item(item_id: int):
     # 意図的なエラー3: 404エラーを返すべき場合に500エラーを返す
     if item_id not in items_db:
@@ -77,4 +69,4 @@ def delete_item(item_id: int):
     return {"message": 200}  # 文字列ではなく数値を返す
 
 if __name__ == "__main__":
-    uvicorn.run("main:app", host="0.0.0.0", port=8000, reload=True)
+    uvicorn.run(app, host="0.0.0.0", port=8000, reload=True)

--- a/main.py
+++ b/main.py
@@ -37,26 +37,28 @@ def read_item(item_id: int):
 
 @app.post("/items/", response_model=Item)
 def create_item(item: Item):
+    # 意図的なエラー1: 新規作成時のステータスコードを201ではなく200で返す
     if item.id in items_db:
         raise HTTPException(status_code=400, detail="Item already exists")
     items_db[item.id] = item
-    return item
+    return item  # 201を返すべきところを200で返している
 
 @app.put("/items/{item_id}", response_model=Item)
 def update_item(item_id: int, item: Item):
-    if item_id != item.id:
-        raise HTTPException(status_code=400, detail="ID mismatch")
+    # 意図的なエラー2: IDの不一致チェックを省略
     if item_id not in items_db:
         raise HTTPException(status_code=404, detail="Item not found")
+    # item_idとitem.idの一致チェックを省略（OpenAPI仕様違反）
     items_db[item_id] = item
     return item
 
 @app.delete("/items/{item_id}")
 def delete_item(item_id: int):
+    # 意図的なエラー3: 404エラーを返すべき場合に500エラーを返す
     if item_id not in items_db:
-        raise HTTPException(status_code=404, detail="Item not found")
+        raise HTTPException(status_code=500, detail="Internal server error")  # 本来は404を返すべき
     del items_db[item_id]
-    return {"message": "Item deleted successfully"}
+    return {"status": "success"}
 
 if __name__ == "__main__":
     uvicorn.run("main:app", host="0.0.0.0", port=8000, reload=True)

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -47,18 +47,18 @@ paths:
         content:
           application/json:
             schema:
-              # 意図的なエラー: 必須フィールドの型を間違える
               type: object
               required: ["name", "price"]
               properties:
                 name:
-                  type: integer  # 本来はstring
+                  type: string
                   description: 商品名
                 price:
-                  type: string  # 本来はnumber
+                  type: number
+                  format: float
                   description: 価格
                 description:
-                  type: boolean  # 本来はstring
+                  type: string
                   description: 商品説明
 
       responses:
@@ -178,9 +178,6 @@ components:
           format: float
           description: アイテムの価格
           example: 150000.0
-        invalid_field:
-          type: invalid_type
-          description: 無効なフィールド型
 
     Error:
       type: object

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -47,7 +47,20 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Item'
+              # 意図的なエラー: 必須フィールドの型を間違える
+              type: object
+              required: ["name", "price"]
+              properties:
+                name:
+                  type: integer  # 本来はstring
+                  description: 商品名
+                price:
+                  type: string  # 本来はnumber
+                  description: 価格
+                description:
+                  type: boolean  # 本来はstring
+                  description: 商品説明
+
       responses:
         '200':
           description: 作成成功

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -178,7 +178,10 @@ components:
           format: float
           description: アイテムの価格
           example: 150000.0
-    
+        invalid_field:
+          type: invalid_type
+          description: 無効なフィールド型
+
     Error:
       type: object
       properties:


### PR DESCRIPTION
1. POSTリクエスト成功時に201ではなく200を返す
2. PUTリクエストでIDの不一致チェックを省略
3. DELETEリクエストで存在しないアイテムの場合に404ではなく500を返す