### PR TITLE
ci: テスト設定を厳密化

### DIFF
--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -58,7 +58,6 @@ jobs:
 
       - name: Validate OpenAPI specification
         id: validate-openapi
-        continue-on-error: true
         run: |
           if npm run validate; then
             echo "status= OpenAPI仕様の検証が成功しました" >> $GITHUB_OUTPUT
@@ -69,7 +68,6 @@ jobs:
 
       - name: Convert OpenAPI to Postman Collection
         id: convert-postman
-        continue-on-error: true
         run: |
           mkdir -p newman
           if npm run postman:convert; then
@@ -81,7 +79,6 @@ jobs:
 
       - name: Run API tests
         id: run-tests
-        continue-on-error: true
         run: |
           ls -la newman/
           if npm run test:api > newman/test-output.txt 2>&1; then

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "API Test Automation Sample",
   "scripts": {
     "validate": "swagger-cli validate openapi.yaml",
-    "postman:convert": "openapi2postmanv2 -s openapi.yaml -o newman/collection.json",
-    "test:api": "newman run newman/collection.json -r cli,htmlextra --reporter-htmlextra-export newman/report.html"
+    "postman:convert": "openapi2postmanv2 -s openapi.yaml -o newman/collection.json --test-status-code=true --test-response-time=false --test-headers=false --test-content=true",
+    "test:api": "newman run newman/collection.json -r cli,htmlextra --reporter-htmlextra-export newman/report.html --bail"
   },
   "dependencies": {
     "openapi-to-postmanv2": "^3.2.1",


### PR DESCRIPTION
1. GitHub Actionsのcontinue-on-errorを削除し、エラー時に確実に失敗するように修正
2. OpenAPI to Postmanの変換時にステータスコードのテストを有効化
3. テスト失敗時に即座に終了するように--bailオプションを追加