### PR TITLE
fix: OpenAPI to Postmanの変換オプションを修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "API Test Automation Sample",
   "scripts": {
     "validate": "swagger-cli validate openapi.yaml",
-    "postman:convert": "openapi2postmanv2 -s openapi.yaml -o newman/collection.json -O requestParametersResolution=Example -O responseParametersResolution=Example",
-    "test:api": "newman run newman/collection.json -r cli,htmlextra --reporter-htmlextra-export newman/report.html --bail newman-reporter-cli"
+    "postman:convert": "openapi2postmanv2 -s openapi.yaml -o newman/collection.json -c postman-config.json",
+    "test:api": "newman run newman/collection.json -r cli,htmlextra --reporter-htmlextra-export newman/report.html --bail"
   },
   "dependencies": {
     "openapi-to-postmanv2": "^3.2.1",

--- a/postman-config.json
+++ b/postman-config.json
@@ -1,0 +1,6 @@
+{
+  "requestParametersResolution": "Example",
+  "responseParametersResolution": "Example",
+  "optimizeConversion": false,
+  "stackLimit": 50
+}


### PR DESCRIPTION
- コマンドラインオプションをJSONファイルに移動
- -c オプションで設定ファイルを指定
- 不要なレポーター設定を削除